### PR TITLE
Fix spelling of 'spite'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following are "assumptive" anti-patterns - the expectations that we bring wi
 - **TOUGH IT OUT** - "It's not that big of a deal. It'll probably go away on it's own if I ignore it."
 - **FATALIST** - "Nobody cares anyway."
 - **NICE GUY** - "I don't want to make anybody uncomfortable."
-- **PARTY POOPER** - "I don't want to ruin the fun that we are still able to have in spit of our issues."
+- **PARTY POOPER** - "I don't want to ruin the fun that we are still able to have in spite of our issues."
 - **THE DEVIL'S POM-POMS** - "Our team is already great, there's no need to try to improve!"
 
     


### PR DESCRIPTION
The Assumptive Antipattern PARTY POOPER had 'in spit of our issues'.